### PR TITLE
chore: mark components as client components

### DIFF
--- a/src/components/movie-card/index.tsx
+++ b/src/components/movie-card/index.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { Movie } from '@/types/movie';
 import StarRating from '../star-rating';
 import './index.scss';

--- a/src/components/star-rating/index.tsx
+++ b/src/components/star-rating/index.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { FaStar } from "react-icons/fa6";
 import { FaRegStar } from "react-icons/fa6";
 import './index.scss';


### PR DESCRIPTION
## Summary
- add `use client` directive to movie-card component
- add `use client` directive to star-rating component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894af8eefd88323be4fcaaf8d636fe7