### PR TITLE
Use env var for TMDB API key

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_TMDB_KEY=<valor>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Environment Variables
+
+Create a `.env.local` file and set the TMDB API key:
+
+```bash
+NEXT_PUBLIC_TMDB_KEY=<valor>
+```
+
+This variable exposes the key to the client-side code to authenticate requests to The Movie Database API.
+
 ## Getting Started
 
 First, run the development server:

--- a/src/components/movie-list/index.tsx
+++ b/src/components/movie-list/index.tsx
@@ -21,7 +21,7 @@ export default function Movielist() {
                 method: 'get',
                 url: 'https://api.themoviedb.org/3/discover/movie',
                 params: {
-                    api_key: '94f9f682e13cc451f5bbcd364ad07000',
+                    api_key: process.env.NEXT_PUBLIC_TMDB_KEY,
                     language: 'pt-BR'
                 }
             });


### PR DESCRIPTION
## Summary
- replace hard-coded TMDB API key with environment variable
- document NEXT_PUBLIC_TMDB_KEY in README
- add .env.local with placeholder key

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894b05c616c8323a7089d509e7d9f4a